### PR TITLE
Fix request version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV ansible_version=2.15.6
 ENV ansible_major_version=2.15
 ENV ansible_commv=8.6.1
 ENV molecule_version=6.0.2
+# https://github.com/docker/docker-py/issues/3256
+ENV requests_version=2.31.0
 ENV umask=022
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 #ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
@@ -15,7 +17,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 # This can be overriden by passing the --break-system-packages option to pip
 RUN rm -f /usr/lib/python3.11/EXTERNALLY-MANAGED && \
     pip3 install --upgrade pip
-RUN pip3 install --disable-pip-version-check --break-system-packages ansible==${ansible_commv} ansible-core==${ansible_version} molecule==${molecule_version} molecule-docker docker ansible-lint flake8 yamllint
+RUN pip3 install --disable-pip-version-check --break-system-packages ansible==${ansible_commv} ansible-core==${ansible_version} molecule==${molecule_version} requests==${requests_version} molecule-docker docker ansible-lint flake8 yamllint
 # python-vagrant pywinrm
 RUN apt-get purge --autoremove -y libc6-dev gcc libssl-dev python3-dev python3-wheel && \
     apt-get clean && \

--- a/Dockerfile-podman
+++ b/Dockerfile-podman
@@ -8,6 +8,8 @@ ENV ansible_version=2.15.6
 ENV ansible_major_version=2.15
 ENV ansible_commv=8.6.1
 ENV molecule_version=6.0.2
+# https://github.com/docker/docker-py/issues/3256
+ENV requests_version=2.31.0
 ENV umask=022
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 #ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
@@ -15,7 +17,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 # This can be overriden by passing the --break-system-packages option to pip
 RUN rm -f /usr/lib/python3.11/EXTERNALLY-MANAGED && \
     pip3 install --upgrade pip
-RUN pip3 install --disable-pip-version-check --break-system-packages ansible==${ansible_commv} ansible-core==${ansible_version} molecule==${molecule_version} molecule-plugins[docker] docker ansible-lint flake8 yamllint podman molecule-plugins[podman]
+RUN pip3 install --disable-pip-version-check --break-system-packages ansible==${ansible_commv} ansible-core==${ansible_version} molecule==${molecule_version} requests==${requests_version} molecule-plugins[docker] docker ansible-lint flake8 yamllint podman molecule-plugins[podman]
 # python-vagrant pywinrm
 RUN apt-get purge --autoremove -y libc6-dev gcc libssl-dev python3-dev python3-wheel && \
     apt-get clean && \

--- a/Dockerfile-root
+++ b/Dockerfile-root
@@ -8,6 +8,8 @@ ENV ansible_version=2.15.6
 ENV ansible_major_version=2.15
 ENV ansible_commv=8.6.1
 ENV molecule_version=6.0.2
+# https://github.com/docker/docker-py/issues/3256
+ENV requests_version=2.31.0
 ENV umask=022
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 #ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
@@ -15,7 +17,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 # This can be overriden by passing the --break-system-packages option to pip
 RUN rm -f /usr/lib/python3.11/EXTERNALLY-MANAGED && \
     pip3 install --upgrade pip
-RUN pip3 install --disable-pip-version-check --break-system-packages ansible==${ansible_commv} ansible-core==${ansible_version} molecule==${molecule_version} molecule-docker docker ansible-lint flake8 yamllint
+RUN pip3 install --disable-pip-version-check --break-system-packages ansible==${ansible_commv} ansible-core==${ansible_version} molecule==${molecule_version} requests==${requests_version} molecule-docker docker ansible-lint flake8 yamllint
 # python-vagrant pywinrm
 RUN apt-get purge --autoremove -y libc6-dev gcc libssl-dev python3-dev python3-wheel && \
     apt-get clean && \


### PR DESCRIPTION
python requests made an incompatible change: https://github.com/psf/requests/commit/c0813a2d910ea6b4f8438b91d315b8d181302356

Thats breaks molecule:

    TASK [Wait for instance(s) deletion to complete] *******************************
    failed: [localhost] (item=instance) => {"ansible_job_id": "j894405820928.93", "ansible_loop_var": "item", "attempts": 2, "changed": false, "finished": 1, "item": {"ansible_job_id": "j894405820928.93", "ansible_loop_var": "item", "changed": true, "failed": 0, "finished": 0, "item": {"cgroupns_mode": "host", "command": "", "image": "geerlingguy/docker-centos7-ansible:latest", "name": "instance", "pre_build_image": true, "privileged": true, "volumes": ["/sys/fs/cgroup:/sys/fs/cgroup:rw"]}, "results_file": "/home/user/.ansible_async/j894405820928.93", "started": 1}, "msg": "Error connecting: Error while fetching server API version: Not supported URL scheme http+docker", "results_file": "/home/user/.ansible_async/j894405820928.93", "started": 1, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

This patch install older python3 requests.

ref: https://github.com/docker/docker-py/issues/3256